### PR TITLE
When logging in the sdk call introspect then logout. so user cannot stay authenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ You can use the `useDiditAuth` hook to retrieve the authentication status and cu
 - `status`: The current authentication status ('loading', 'authenticated', 'unauthenticated')
 
   ```tsx
-  import { AuthenticationStatus } from 'didit-sdk';
+  import { DiditAuthStatus } from 'didit-sdk';
   ```
 
 - `accessToken`: The current **Didit** access token

--- a/README.md
+++ b/README.md
@@ -371,3 +371,42 @@ return (
 )
 
 ```
+
+##### Special cases
+
+###### App with localized routing
+
+In case you have localized routing in your app there are two possible ways to configure the `redirectUri` prop in the `DiditAuthProvider`:
+
+1. You create a single page and route withouth localization and use the `redirectUri` prop as usual:
+
+```tsx
+import { DiditAuthProvider } from 'didit-sdk';
+
+...
+
+  <DiditAuthProvider
+    clientId="676573"
+    redirectUri="http://your-app.com/no-locale-login/callback"
+  >
+    {children}
+  </DiditAuthProvider>
+```
+
+2. You can use a dynamic `redirectUri` prop based on the current language or locale:
+
+```tsx
+
+import { DiditAuthProvider } from 'didit-sdk';
+
+...
+
+  <DiditAuthProvider
+    clientId="676573"
+    redirectUri={`http://your-app.com/${locale}/login/callback`}
+  >
+    {children}
+  </DiditAuthProvider>
+```
+
+> Note: In case you use the second option, you will need to add each of the `redirectUri` to your **Didit** client configuration for each language or locale to support all the possible routes.

--- a/examples/with-create-react-app/src/pages/Home.tsx
+++ b/examples/with-create-react-app/src/pages/Home.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
   DiditAuthMethod,
+  DiditAuthStatus,
   DiditLogin,
   DiditLoginButton,
   DiditLoginMode,
@@ -25,6 +26,15 @@ const Home = () => {
     onLogout: () => console.log('useDiditAuth: Logged out from Didit'),
   });
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  // Simulate a request to a protected resource when the user is authenticated
+  useEffect(() => {
+    if (status === DiditAuthStatus.AUTHENTICATED) {
+      console.log(
+        'User is authenticated in Didit, making a request to a protected resource...'
+      );
+    }
+  }, [status]);
 
   return (
     <div

--- a/examples/with-nextjs/src/pages/_app.tsx
+++ b/examples/with-nextjs/src/pages/_app.tsx
@@ -36,12 +36,12 @@ export default function App({ Component, pageProps }: AppProps) {
       config={wagmiConfig} // The one that was configured before for Wagmi
     >
       <DiditAuthProvider
+        authBaseUrl={process.env.NEXT_PUBLIC_DIDIT_AUTH_BASE_URL || ''}
         authMethods={[
           DiditAuthMethod.WALLET,
           DiditAuthMethod.GOOGLE,
           DiditAuthMethod.APPLE,
         ]}
-        authBaseUrl={process.env.NEXT_PUBLIC_DIDIT_AUTH_BASE_URL || ''}
         chains={chains}
         claims={process.env.NEXT_PUBLIC_DIDIT_CLAIMS}
         clientId={process.env.NEXT_PUBLIC_DIDIT_CLIENT_ID || ''}

--- a/packages/didit-sdk/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/didit-sdk/src/components/ConnectButton/ConnectButton.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../css/sprinkles.css';
 import { touchableStyles } from '../../css/touchableStyles';
 import { useConnectionStatus } from '../../hooks/useConnectionStatus';
-import { AuthenticationStatus } from '../../types';
+import { DiditAuthStatus } from '../../types';
 import { isMobile } from '../../utils/isMobile';
 import { AsyncImage } from '../AsyncImage/AsyncImage';
 import { Avatar } from '../Avatar/Avatar';
@@ -51,8 +51,7 @@ export function ConnectButton({
         openChainModal,
         openConnectModal,
       }) => {
-        const ready =
-          mounted && connectionStatus !== AuthenticationStatus.LOADING;
+        const ready = mounted && connectionStatus !== DiditAuthStatus.LOADING;
         const unsupportedChain = chain?.unsupported ?? false;
 
         return (

--- a/packages/didit-sdk/src/components/ConnectButton/ConnectButtonRenderer.tsx
+++ b/packages/didit-sdk/src/components/ConnectButton/ConnectButtonRenderer.tsx
@@ -5,7 +5,7 @@ import { useIsMounted } from '../../hooks/useIsMounted';
 import { useMainnetEnsAvatar } from '../../hooks/useMainnetEnsAvatar';
 import { useMainnetEnsName } from '../../hooks/useMainnetEnsName';
 import { useRecentTransactions } from '../../transactions/useRecentTransactions';
-import { AuthenticationStatus } from '../../types';
+import { DiditAuthStatus } from '../../types';
 import { useAsyncImage } from '../AsyncImage/useAsyncImage';
 import {
   useAccountModal,
@@ -43,7 +43,7 @@ export interface ConnectButtonRendererProps {
       unsupported?: boolean;
     };
     mounted: boolean;
-    authenticationStatus?: AuthenticationStatus;
+    authenticationStatus?: DiditAuthStatus;
     openAccountModal: () => void;
     openChainModal: () => void;
     openConnectModal: () => void;

--- a/packages/didit-sdk/src/components/RainbowKitProvider/AuthenticationContext.tsx
+++ b/packages/didit-sdk/src/components/RainbowKitProvider/AuthenticationContext.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
 } from 'react';
 import { useAccount } from 'wagmi';
-import { AuthenticationStatus } from '../../types';
+import { DiditAuthStatus } from '../../types';
 
 export interface AuthenticationAdapter {
   getNonce: () => Promise<string>;
@@ -22,7 +22,7 @@ export interface AuthenticationAdapter {
 
 export interface RainbowKitAuthenticationConfig {
   adapter: AuthenticationAdapter;
-  status: AuthenticationStatus;
+  status: DiditAuthStatus;
   token: string | boolean;
   address: string;
   error: string;
@@ -70,7 +70,7 @@ export function RainbowKitAuthenticationProvider({
     if (onceRef.current) return;
     onceRef.current = true;
 
-    if (isDisconnected && status === AuthenticationStatus.AUTHENTICATED) {
+    if (isDisconnected && status === DiditAuthStatus.AUTHENTICATED) {
       adapter.signOut();
     }
   }, [status, adapter, isDisconnected, token, address]);

--- a/packages/didit-sdk/src/contexts/diditAuthContext/diditAuthContext.ts
+++ b/packages/didit-sdk/src/contexts/diditAuthContext/diditAuthContext.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import {
-  AuthenticationStatus,
   DiditAuthMethod,
+  DiditAuthStatus,
   DiditTokenInfo,
   DiditUser,
 } from '../../types';
@@ -13,7 +13,7 @@ interface DiditAuthContextState {
   availableAuthMethods: DiditAuthMethod[];
   error?: string;
   logout: () => void;
-  status: AuthenticationStatus;
+  status: DiditAuthStatus;
   accessToken?: string;
   refreshToken?: string;
   accessTokenInfo?: DiditTokenInfo;
@@ -28,7 +28,7 @@ const defaultState: DiditAuthContextState = {
   error: undefined,
   logout: () => {},
   refreshToken: undefined,
-  status: AuthenticationStatus.LOADING,
+  status: DiditAuthStatus.UNAUTHENTICATED,
   user: undefined,
 };
 

--- a/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
@@ -2,8 +2,8 @@ import { useLocalStorageValue } from '@react-hookz/web';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { DIDIT } from '../../config';
 import {
-  AuthenticationStatus,
   DiditAuthMethod,
+  DiditAuthStatus,
   DiditEmailAuthMode,
   DiditTokensData,
   SocialAuthProvider,
@@ -26,7 +26,7 @@ interface DiditEmailAuthProviderProps {
   onUpdateAuthMethod?: (authMethod: DiditAuthMethod) => void;
   redirectUri: string;
   scope: string;
-  status: AuthenticationStatus;
+  status: DiditAuthStatus;
   token?: string;
 }
 
@@ -216,7 +216,6 @@ const DiditEmailAuthProvider = ({
   const getDiditToken = useCallback(
     async (_authorizationCode: string, _codeVerifier: string) => {
       const tokenUrl = `${emailAuthBaseUrl}${DIDIT.EMAIL_AUTH_TOKEN_PATH}`;
-
       const tokenBody = new URLSearchParams();
       tokenBody.append('client_id', clientId);
       tokenBody.append('code', _authorizationCode);
@@ -233,7 +232,6 @@ const DiditEmailAuthProvider = ({
           .catch(error =>
             handleTokenError('Error retrieving Didit token', String(error))
           );
-
         handleTokenSuccess(tokenData);
         return tokenData;
       } catch (error) {
@@ -298,7 +296,10 @@ const DiditEmailAuthProvider = ({
     const windowUrl = windowLocation.origin + windowLocation.pathname;
 
     // If there is a parent window and redirect uri matches, we are in the popup
-    if (isPopupWindow && windowUrl === redirectUri) {
+    if (
+      isPopupWindow &&
+      windowUrl.replace(/\/$/, '') === redirectUri.replace(/\/$/, '')
+    ) {
       // Redirect the parent window to the current URL with search params
       window.opener.location.href = windowLocation.href;
       // Close the popup

--- a/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
@@ -222,7 +222,7 @@ const DiditEmailAuthProvider = ({
       tokenBody.append('code', _authorizationCode);
       tokenBody.append('code_verifier', _codeVerifier);
       tokenBody.append('grant_type', 'authorization_code');
-      tokenBody.append('redirect_uri', `http://localhost:3000/callback`);
+      tokenBody.append('redirect_uri', redirectUri);
 
       try {
         const tokenData = await fetch(tokenUrl, {
@@ -240,7 +240,13 @@ const DiditEmailAuthProvider = ({
         handleTokenError('Error retrieving Didit token', String(error));
       }
     },
-    [clientId, emailAuthBaseUrl, handleTokenError, handleTokenSuccess]
+    [
+      clientId,
+      emailAuthBaseUrl,
+      handleTokenError,
+      handleTokenSuccess,
+      redirectUri,
+    ]
   );
 
   const loginWithGoogle = useCallback(

--- a/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditEmailAuthContext/DiditEmailAuthProvider.tsx
@@ -140,16 +140,28 @@ const DiditEmailAuthProvider = ({
       const responseType = DIDIT.EMAIL_AUTH_RESPONSE_TYPE;
       const idp = _socialAuthProvider;
       setSocialAuthProvider(_socialAuthProvider);
-      const encodedRedirectUrl = encodeURIComponent(redirectUri);
 
       // Generate a random string as code_verifier and code_challenge, and store the code_verifier in local storage
       const _codeVerifier = generateCodeVerifier();
       const codeChallenge = await generateCodeChallenge(_codeVerifier);
       setCodeVerifier(_codeVerifier);
 
-      // Generate the authorization url
-      const authorizeUrl = `${authorizationUrl}?client_id=${clientId}&response_type=${responseType}&scope=${scope}&claims=${claims}&redirect_uri=${encodedRedirectUrl}&code_verifier=${codeVerifier}&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}&idp=${idp}`;
+      const params = new URLSearchParams({
+        claims,
+        client_id: clientId,
+        code_challenge: codeChallenge,
+        code_challenge_method: codeChallengeMethod,
+        code_verifier: _codeVerifier,
+        idp,
+        redirect_uri: redirectUri,
+        response_type: responseType,
+        scope,
+      });
 
+      // Generate the authorization url
+      const authorizeUrl = `${authorizationUrl}?${params.toString()}`;
+
+      // Generate the authorization url
       return authorizeUrl;
     },
     [
@@ -161,7 +173,6 @@ const DiditEmailAuthProvider = ({
       clientId,
       scope,
       claims,
-      codeVerifier,
       onDeauthenticate,
     ]
   );

--- a/packages/didit-sdk/src/contexts/diditEmailAuthContext/diditEmailAuthContext.ts
+++ b/packages/didit-sdk/src/contexts/diditEmailAuthContext/diditEmailAuthContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { AuthenticationStatus, SocialAuthProvider } from '../../types';
+import { DiditAuthStatus, SocialAuthProvider } from '../../types';
 
 const CONTEXT_NAME = 'DiditEmailAuth';
 
@@ -9,7 +9,7 @@ interface DiditEmailAuthContextState {
   loginWithEmail: () => void;
   loginWithGoogle: () => void;
   loginWithSocial: (socialAuthProvider: SocialAuthProvider) => void;
-  status: AuthenticationStatus;
+  status: DiditAuthStatus;
   token?: string;
 }
 
@@ -19,7 +19,7 @@ const defaultState: DiditEmailAuthContextState = {
   loginWithEmail: () => {},
   loginWithGoogle: () => {},
   loginWithSocial: () => {},
-  status: AuthenticationStatus.LOADING,
+  status: DiditAuthStatus.UNAUTHENTICATED,
   token: undefined,
 };
 

--- a/packages/didit-sdk/src/contexts/diditWalletContext/DiditWalletProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditWalletContext/DiditWalletProvider.tsx
@@ -8,11 +8,7 @@ import {
 } from '../../components/RainbowKitProvider/AuthenticationContext';
 import { RainbowKitProviderProps } from '../../components/RainbowKitProvider/DiditRainbowkitProvider';
 import { DIDIT } from '../../config';
-import {
-  AuthenticationStatus,
-  DiditAuthMethod,
-  DiditTokensData,
-} from '../../types';
+import { DiditAuthMethod, DiditAuthStatus, DiditTokensData } from '../../types';
 
 export type DiditWalletProviderProps = {
   authMethod?: DiditAuthMethod;
@@ -25,7 +21,7 @@ export type DiditWalletProviderProps = {
   onError?: (error: string) => void;
   onUpdateTokens?: (tokens: DiditTokensData) => void;
   scope: string;
-  status?: AuthenticationStatus;
+  status?: DiditAuthStatus;
   token?: string;
   tokenAuthorizationPath?: string;
   walletAuthBaseUrl?: string;
@@ -43,7 +39,7 @@ export function DiditWalletProvider({
   onError = () => {},
   onUpdateTokens = () => {},
   scope,
-  status = AuthenticationStatus.LOADING,
+  status = DiditAuthStatus.UNAUTHENTICATED,
   token = '',
   tokenAuthorizationPath = DIDIT.DEFAULT_WALLET_AUTH_TOKEN_PATH,
   walletAuthBaseUrl = DIDIT.DEFAULT_WALLET_AUTH_BASE_URL,

--- a/packages/didit-sdk/src/hooks/useDiditAuth.ts
+++ b/packages/didit-sdk/src/hooks/useDiditAuth.ts
@@ -3,7 +3,7 @@ import { RainbowKitAuthenticationContext } from '../components/RainbowKitProvide
 import { useConnectModal } from '../components/RainbowKitProvider/ModalContext';
 import { useDiditAuthContext } from '../contexts/diditAuthContext';
 import { useDiditEmailAuthContext } from '../contexts/diditEmailAuthContext';
-import { AuthenticationStatus, DiditAuthMethod } from '../types';
+import { DiditAuthMethod, DiditAuthStatus } from '../types';
 import usePreviousState from './usePreviousState';
 
 interface UseDiditAuthProps {
@@ -37,12 +37,12 @@ const useDiditAuth = ({
 
   // Boolean status
   const isAuthenticated = useMemo(() => {
-    if (status === AuthenticationStatus.AUTHENTICATED) return true;
-    if (status === AuthenticationStatus.UNAUTHENTICATED) return false;
+    if (status === DiditAuthStatus.AUTHENTICATED) return true;
+    if (status === DiditAuthStatus.UNAUTHENTICATED) return false;
     return undefined;
   }, [status]);
   const prevIsAuthenticated = usePreviousState(isAuthenticated);
-  const isLoading = status === AuthenticationStatus.LOADING;
+  const isLoading = status === DiditAuthStatus.LOADING;
   const hasError = !!error;
 
   const login = useCallback(

--- a/packages/didit-sdk/src/index.ts
+++ b/packages/didit-sdk/src/index.ts
@@ -40,7 +40,7 @@ export {
   DiditAuthMethod,
   DiditEmailAuthMode,
   DiditLoginMode,
-  AuthenticationStatus,
+  DiditAuthStatus,
 } from './types';
 export {
   useDiditStatus,

--- a/packages/didit-sdk/src/types.ts
+++ b/packages/didit-sdk/src/types.ts
@@ -20,7 +20,7 @@ enum DiditAuthMethod {
   WALLET = 'wallet',
 }
 
-enum AuthenticationStatus {
+enum DiditAuthStatus {
   LOADING = 'loading',
   AUTHENTICATED = 'authenticated',
   UNAUTHENTICATED = 'unauthenticated',
@@ -53,7 +53,7 @@ export {
   SocialAuthProvider,
   DiditAuthMethod,
   DiditLoginMode,
-  AuthenticationStatus,
+  DiditAuthStatus,
   type DiditTokenInfo,
   type DiditUser,
   type DiditTokensData,

--- a/packages/didit-sdk/src/wallets/useWalletConnectors.ts
+++ b/packages/didit-sdk/src/wallets/useWalletConnectors.ts
@@ -1,6 +1,6 @@
 import { Connector, useConnect } from 'wagmi';
 import { useDiditAuthContext } from '../contexts/diditAuthContext';
-import { AuthenticationStatus, DiditAuthMethod } from '../types';
+import { DiditAuthMethod, DiditAuthStatus } from '../types';
 import { flatten } from '../utils/flatten';
 import { indexBy } from '../utils/indexBy';
 import { isNotNullish } from '../utils/isNotNullish';
@@ -34,7 +34,7 @@ export function useWalletConnectors(): WalletConnector[] {
 
     // Force logout if the user is authenticated with a non-wallet method before connecting a wallet
     if (
-      status === AuthenticationStatus.AUTHENTICATED &&
+      status === DiditAuthStatus.AUTHENTICATED &&
       authMethod !== DiditAuthMethod.WALLET
     )
       logout();


### PR DESCRIPTION
### Summary

- Fix hardcoded redirectUri
- Complete documentation with "App with localized routing"
- Rework `DiditAuthStatus`
- Added loading status until access token is validated or refreshed


### Issues

- Ga 4382 when logging in the sdk call introspect then logout. so user cannot stay authenticated
https://gamium.atlassian.net/browse/GA-4382
- Login with Apple and Google is closing multiple times
https://gamium.atlassian.net/browse/GA-4381
It should not happen with this version when published