### PR TITLE
Fix/multiple tabs localstorage sync

### DIFF
--- a/packages/didit-sdk/src/contexts/diditAuthContext/DiditAuthProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditAuthContext/DiditAuthProvider.tsx
@@ -293,8 +293,7 @@ const DiditAuthProvider = ({
       firstRender.current = false;
       return;
     }
-
-    if (!!accessToken && !!authMethod) {
+    if (!!accessToken && !!refreshToken) {
       try {
         // setStatus(DiditAuthStatus.LOADING); // Set status to loading while checking the access token
         checkAccessToken();
@@ -305,10 +304,11 @@ const DiditAuthProvider = ({
       }
     } else {
       // Consolidate logout status in both frontend and backend
-      forceCompleteLogout();
+      // instead of forcing logout we only set the status to unauthenticated
+      setStatus(DiditAuthStatus.UNAUTHENTICATED);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authMethod, accessToken]);
+  }, [accessToken, refreshToken]);
 
   // Validate configurable props
   useEffect(() => {

--- a/packages/didit-sdk/src/contexts/diditAuthContext/DiditAuthProvider.tsx
+++ b/packages/didit-sdk/src/contexts/diditAuthContext/DiditAuthProvider.tsx
@@ -66,28 +66,19 @@ const DiditAuthProvider = ({
 }: DiditAuthProviderProps) => {
   const firstRender = useRef(true);
 
-  const {
-    remove: removeAccessToken,
-    set: setAccessToken,
-    value: accessToken,
-  } = useLocalStorageValue<string>(DIDIT.TOKEN_COOKIE_NAME, {
-    initializeWithValue: false,
-  });
-  const {
-    remove: removeRefreshToken,
-    set: setRefreshToken,
-    value: refreshToken,
-  } = useLocalStorageValue<string>(DIDIT.REFRESH_TOKEN_COOKIE_NAME, {
-    initializeWithValue: false,
-  });
+  const { set: setAccessToken, value: accessToken } =
+    useLocalStorageValue<string>(DIDIT.TOKEN_COOKIE_NAME, {
+      initializeWithValue: false,
+    });
+  const { set: setRefreshToken, value: refreshToken } =
+    useLocalStorageValue<string>(DIDIT.REFRESH_TOKEN_COOKIE_NAME, {
+      initializeWithValue: false,
+    });
 
-  const {
-    remove: removeAuthMethod,
-    set: setAuthMethod,
-    value: authMethod,
-  } = useLocalStorageValue<DiditAuthMethod>(DIDIT.AUTH_METHOD_COOKIE_NAME, {
-    initializeWithValue: false,
-  });
+  const { set: setAuthMethod, value: authMethod } =
+    useLocalStorageValue<DiditAuthMethod>(DIDIT.AUTH_METHOD_COOKIE_NAME, {
+      initializeWithValue: false,
+    });
 
   const [status, setStatus] = useState<DiditAuthStatus>(INITIAL_AUTH_STATUS);
   const [error, setError] = useState('');
@@ -118,9 +109,12 @@ const DiditAuthProvider = ({
   );
 
   const removeTokens = useCallback(() => {
-    removeAccessToken();
-    removeRefreshToken();
-  }, [removeAccessToken, removeRefreshToken]);
+    // instead of remove data from local storage, we set empty value
+    // to trigget localstorage change event, remove the value doesn't trigger
+    // the change. so the second tab desn't know that value is deleted
+    setAccessToken('');
+    setRefreshToken('');
+  }, [setAccessToken, setRefreshToken]);
 
   const authenticate = useCallback(
     (_authMethod: DiditAuthMethod) => {
@@ -163,9 +157,9 @@ const DiditAuthProvider = ({
   const deauthenticate = useCallback(() => {
     setStatus(DiditAuthStatus.UNAUTHENTICATED);
     removeTokens();
-    removeAuthMethod();
+    setAuthMethod('' as DiditAuthMethod);
     setError('');
-  }, [removeAuthMethod, removeTokens]);
+  }, [setAuthMethod, removeTokens]);
 
   // forceCompleteLogout is used to force a complete logout from the Didit service and from the frontend.
   const forceCompleteLogout = useCallback(() => {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 prefer-workspace-packages: true
 packages:
   - 'packages/*'
-  - 'packages/create-rainbowkit/**/*-app'
-  - 'site'
   - 'examples/*'


### PR DESCRIPTION
- the problem : when you have two tabs and the first one update a local storage value, the second receives an event for  localstorage change. changing multiple values as we do, will trigger multiple events in a row. 
in out case this is what happens:

-  tab1 authenticate and set 3 value to local storage, accessToken, refreshtoken and authMethod
-  tab2 get 3 change events in a row, when the first event arrive (accessToken) it triggers the useEffect[depends on accessToken and authMethod], 
-  tab2 in the useEffect we check if we have accessToken and AuthMethod : 
`   if (!!accessToken && !!authMethod) {
      try {
        // setStatus(DiditAuthStatus.LOADING); // Set status to loading while checking the access token
        checkAccessToken();
      } catch (error) {
        console.warn('Error checking access token: ', error);
        // Consolidate logout status in both frontend and backend
        forceCompleteLogout();
      }
    } else {
      // Consolidate logout status in both frontend and backend
        forceCompleteLogout();
    }`

- tab2 sense we have only the accessToken, we trigger logout and remove values from local storage
- tab1 don't receive any change event , because we remove the whole value from tab2 (the remove doesn't trigger the change event). 
- tab1 is authenticated but it doesn't have access and refresh tokens. that's why the calls to the api don't have the access token and fail.

there is two solutions to this:
- [x] check tokes status, when we have two values (accessToken and RefreshToken), and don't trigger logout if we don't have them just set the status to unauthenticated. and don't use authMethod. because it changes when the use click on the method and before authenticating.  
- [] gather all the value into one local storage value, so we we change it, we receive only one event. 





** instead of removing the values when the user logout. I set them to empty values. because the remove doesn't trigger an event for other tabs. so when the user logout from one tab the others tabs don't know





Uploading Screen Recording 2023-11-08 at 01.35.02.mov…



    