### PR TITLE
add footer and header to didit login

### DIFF
--- a/examples/with-nextjs/src/pages/_app.tsx
+++ b/examples/with-nextjs/src/pages/_app.tsx
@@ -51,12 +51,15 @@ export default function App({ Component, pageProps }: AppProps) {
           console.warn('Logged in Didit with', _authMethod)
         }
         onLogout={() => console.warn('Logged out Didit')}
-        redirectUri={process.env.NEXT_PUBLIC_DIDIT_REDIRECT_URI || ''}
+        redirectUri={
+          process.env.NEXT_PUBLIC_DIDIT_REDIRECT_URI || 'http://localhost'
+        }
         scope={process.env.NEXT_PUBLIC_DIDIT_SCOPE}
         theme={lightTheme()}
         tokenAuthorizationPath="/token"
         walletAuthBaseUrl={
-          process.env.NEXT_PUBLIC_DIDIT_WALLET_AUTH_BASE_URL || ''
+          process.env.NEXT_PUBLIC_DIDIT_WALLET_AUTH_BASE_URL ||
+          'http://localhost'
         }
         walletAuthorizationPath="/wallet-authorization"
       >

--- a/examples/with-nextjs/src/pages/index.tsx
+++ b/examples/with-nextjs/src/pages/index.tsx
@@ -134,12 +134,52 @@ export default function Home() {
                   <DiditLogin
                     isModalOpen={isLoginModalOpen}
                     onModalClose={() => setIsLoginModalOpen(false)}
+                    header={
+                      <div className="w-full">
+                        <h1 className="m-0 mb-4 text-2xl font-medium">
+                          Signup to
+                          <strong className="text-blue-700"> Didit</strong>
+                        </h1>
+                        <p>All you issentials in one place</p>
+                      </div>
+                    }
+                    footer={
+                      <div className=" text-sm">
+                        You don't have an account?{' '}
+                        <a href="mode=signup">
+                          <span className="font-bold text-blue-700">
+                            register
+                          </span>
+                        </a>
+                      </div>
+                    }
                   />
                 </div>
               )}
               {modeSelected === 'embedded' && (
                 <div className="flex flex-col space-y-2">
-                  <DiditLogin mode={DiditLoginMode.EMBEDDED} />
+                  <DiditLogin
+                    mode={DiditLoginMode.EMBEDDED}
+                    header={
+                      <div className="w-full">
+                        <h1 className="m-0 mb-4 text-2xl font-medium">
+                          Signup to
+                          <strong className="text-blue-700"> Didit</strong>
+                        </h1>
+                        <p>All you issentials in one place</p>
+                      </div>
+                    }
+                    footer={
+                      <div className=" text-sm">
+                        You don't have an account?{' '}
+                        <a href="mode=signup">
+                          <span className="font-bold text-blue-700">
+                            register
+                          </span>
+                        </a>
+                      </div>
+                    }
+                  />
                 </div>
               )}
             </>

--- a/examples/with-nextjs/src/pages/index.tsx
+++ b/examples/with-nextjs/src/pages/index.tsx
@@ -148,7 +148,7 @@ export default function Home() {
                           Signup to
                           <strong className="text-blue-700"> Didit</strong>
                         </h1>
-                        <p>All you issentials in one place</p>
+                        <p>All your life essentials in one place</p>
                       </div>
                     }
                     isModalOpen={isLoginModalOpen}

--- a/examples/with-nextjs/src/pages/index.tsx
+++ b/examples/with-nextjs/src/pages/index.tsx
@@ -132,8 +132,16 @@ export default function Home() {
               {modeSelected === 'modal' && (
                 <div className="flex flex-col space-y-2">
                   <DiditLogin
-                    isModalOpen={isLoginModalOpen}
-                    onModalClose={() => setIsLoginModalOpen(false)}
+                    footer={
+                      <div className=" text-sm">
+                        You dont have an account?{' '}
+                        <a href="mode=signup">
+                          <span className="font-bold text-blue-700">
+                            register
+                          </span>
+                        </a>
+                      </div>
+                    }
                     header={
                       <div className="w-full">
                         <h1 className="m-0 mb-4 text-2xl font-medium">
@@ -143,23 +151,24 @@ export default function Home() {
                         <p>All you issentials in one place</p>
                       </div>
                     }
-                    footer={
-                      <div className=" text-sm">
-                        You don't have an account?{' '}
-                        <a href="mode=signup">
-                          <span className="font-bold text-blue-700">
-                            register
-                          </span>
-                        </a>
-                      </div>
-                    }
+                    isModalOpen={isLoginModalOpen}
+                    onModalClose={() => setIsLoginModalOpen(false)}
                   />
                 </div>
               )}
               {modeSelected === 'embedded' && (
                 <div className="flex flex-col space-y-2">
                   <DiditLogin
-                    mode={DiditLoginMode.EMBEDDED}
+                    footer={
+                      <div className=" text-sm">
+                        You dont have an account?{' '}
+                        <a href="mode=signup">
+                          <span className="font-bold text-blue-700">
+                            register
+                          </span>
+                        </a>
+                      </div>
+                    }
                     header={
                       <div className="w-full">
                         <h1 className="m-0 mb-4 text-2xl font-medium">
@@ -169,16 +178,7 @@ export default function Home() {
                         <p>All you issentials in one place</p>
                       </div>
                     }
-                    footer={
-                      <div className=" text-sm">
-                        You don't have an account?{' '}
-                        <a href="mode=signup">
-                          <span className="font-bold text-blue-700">
-                            register
-                          </span>
-                        </a>
-                      </div>
-                    }
+                    mode={DiditLoginMode.EMBEDDED}
                   />
                 </div>
               )}

--- a/packages/didit-sdk/package.json
+++ b/packages/didit-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "didit-sdk",
-  "version": "2.0.4",
+  "version": "2.0.6",
   "description": "A collection of utilities to log in, authenticate and authorize in Didit protocol.",
   "files": [
     "dist",

--- a/packages/didit-sdk/src/components/DiditLogin/DiditLogin.tsx
+++ b/packages/didit-sdk/src/components/DiditLogin/DiditLogin.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { DiditLoginMode } from '../../types';
 import { LoginDialog } from '../LoginDialog';
 import LoginModal from '../LoginModal/LoginModal';
@@ -20,12 +20,16 @@ interface DiditLoginProps {
   onModalClose?: () => void;
   title?: string;
   description?: string;
+  header?: ReactNode;
+  footer?: ReactNode;
 }
 
 const DiditLogin: FC<DiditLoginProps> = ({
   buttonClassName = '',
   dataTestId = '',
   description = LOGIN_DIALOG_DEFAULT_DESCRIPTION,
+  footer = null,
+  header = null,
   isModalOpen = false,
   mode = DiditLoginMode.MODAL,
   onModalClose = () => {},
@@ -39,6 +43,8 @@ const DiditLogin: FC<DiditLoginProps> = ({
       buttonClassName={buttonClassName}
       dataTestId={dataTestId}
       description={description}
+      footer={footer}
+      header={header}
       isOpen={isModalOpen}
       onClose={onModalClose}
       title={title}

--- a/packages/didit-sdk/src/components/LoginDialog/LoginDialog.tsx
+++ b/packages/didit-sdk/src/components/LoginDialog/LoginDialog.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useState } from 'react';
 // import LeftArrowButton from '../LeftArrowButton/LeftArrowButton';
 import LoginOptionsDialog from './LoginOptionsDialog';
 import SocialOptionsDialog from './SocialOptionsDialog';
@@ -7,6 +7,8 @@ interface LoginDialogProps {
   wrapperClassName?: string;
   buttonClassName?: string;
   dataTestId?: string;
+  header?: ReactNode;
+  footer?: ReactNode;
   title: string;
   description: string;
 }
@@ -14,6 +16,8 @@ const LoginDialog: FC<LoginDialogProps> = ({
   buttonClassName = '',
   dataTestId = '',
   description = '',
+  footer,
+  header,
   title,
   wrapperClassName,
 }) => {
@@ -42,6 +46,8 @@ const LoginDialog: FC<LoginDialogProps> = ({
           buttonClassName={buttonClassName}
           dataTestId={dataTestId}
           description={description}
+          footer={footer}
+          header={header}
           onLoginWithSocials={HandleLoginWithSocials}
           title={title}
           wrapperClassName={wrapperClassName}

--- a/packages/didit-sdk/src/components/LoginDialog/LoginOptionsDialog.tsx
+++ b/packages/didit-sdk/src/components/LoginDialog/LoginOptionsDialog.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { useDiditAuth } from '../../hooks';
 import { DiditAuthMethod, SocialAuthProvider } from '../../types';
 import { DiditButton } from '../DiditButton';
@@ -15,12 +15,16 @@ interface LoginOptionsDialogProps {
   onLoginWithSocials?: () => void;
   title: string;
   description: string;
+  header?: ReactNode;
+  footer?: ReactNode;
 }
 
 const LoginOptionsDialog: FC<LoginOptionsDialogProps> = ({
   buttonClassName = '',
   dataTestId = '',
   description,
+  footer = null,
+  header = null,
   onLoginWithSocials = () => {},
   title,
   wrapperClassName = '',
@@ -45,10 +49,14 @@ const LoginOptionsDialog: FC<LoginOptionsDialogProps> = ({
 
   return (
     <div className={LoginClassName} data-testid={dataTestId}>
-      <div className="dialog-text">
-        <h2 className="dialog-text-title">{title}</h2>
-        <p className="dialog-text-description">{description}</p>
-      </div>
+      {header ? (
+        header
+      ) : (
+        <div className="dialog-text">
+          <h2 className="dialog-text-title">{title}</h2>
+          <p className="dialog-text-description">{description}</p>
+        </div>
+      )}
       <div className="dialog-buttons">
         {/*
         { isEmailAuthAvailable && (
@@ -72,13 +80,15 @@ const LoginOptionsDialog: FC<LoginOptionsDialogProps> = ({
         )}
         {isWalletAuthAvailable && <DiditConnectWalletButton />}
       </div>
-      <div className="dialog-error">
-        <DiditError
-          description={error || ''}
-          isHidden={!hasError}
-          title="Opps something went wrong"
-        />
-      </div>
+      {hasError && (
+        <div className="dialog-error">
+          <DiditError
+            description={error || ''}
+            title="Opps something went wrong"
+          />
+        </div>
+      )}
+      {footer}
     </div>
   );
 };

--- a/packages/didit-sdk/src/components/LoginModal/LoginModal.tsx
+++ b/packages/didit-sdk/src/components/LoginModal/LoginModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { Box } from '../Box/Box';
 import { CloseButton } from '../CloseButton/CloseButton';
 import { Dialog } from '../Dialog/Dialog';
@@ -13,12 +13,16 @@ interface LoginModalProps {
   onClose: () => void;
   title: string;
   description: string;
+  header: ReactNode;
+  footer: ReactNode;
 }
 
 const LoginModal: FC<LoginModalProps> = ({
   buttonClassName = '',
   dataTestId = '',
   description,
+  footer = null,
+  header = null,
   isOpen = false,
   onClose = () => {},
   title,
@@ -47,6 +51,8 @@ const LoginModal: FC<LoginModalProps> = ({
             buttonClassName={buttonClassName}
             dataTestId={dataTestId}
             description={description}
+            footer={footer}
+            header={header}
             title={title}
             wrapperClassName={wrapperClassName}
           />


### PR DESCRIPTION
add footer and header as react node props on login component for more customization 

<img width="999" alt="Screenshot 2023-11-14 at 14 47 55" src="https://github.com/didit-protocol/didit-sdk/assets/52551794/a0f2b3c8-cbe9-4945-9899-6cb1afb564c7">
<img width="1056" alt="Screenshot 2023-11-14 at 14 48 23" src="https://github.com/didit-protocol/didit-sdk/assets/52551794/0e221ce3-9335-47ec-a29c-a00eeb1de4c8">

